### PR TITLE
Remove network: host in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,6 @@ services:
       - ./packages:/home/ubuntu/packages
     ports:
       - "4000:4000"
-    network_mode: host
     command: su ubuntu -c "cd /home/ubuntu/packages/backend && npm install && npm start"
   frontend:
     build:
@@ -18,5 +17,4 @@ services:
       - ./packages:/home/ubuntu/packages
     ports:
       - "3000:3000"
-    network_mode: host
     command: su ubuntu -c "cd /home/ubuntu/packages/frontend && npm install && npm start"


### PR DESCRIPTION
It is
1. Not needed since we expose the ports anyway
2. Didn't seem to work on windows (at least the WSL2 backend)

Fixes #47 