### PR TITLE
Fix eslint rule to use typescript variants

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
   extends: [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
   ],
   globals: {
@@ -17,5 +18,6 @@ module.exports = {
     ecmaVersion: 2018,
     sourceType: "module"
   },
+  rules: {},
   plugins: ["@typescript-eslint"]
 };

--- a/packages/frontend/.eslintrc.js
+++ b/packages/frontend/.eslintrc.js
@@ -7,6 +7,7 @@ module.exports = {
     "eslint:recommended",
     "plugin:react/recommended",
     "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended"
   ],
   globals: {


### PR DESCRIPTION
Now uses typescript variants of recommended eslint rules and disables the incompatible rules