### PR TITLE
Re-factor environment variable for docker hub release

### DIFF
--- a/packages/frontend/src/functions/Environment.ts
+++ b/packages/frontend/src/functions/Environment.ts
@@ -1,0 +1,10 @@
+export function getBackendUrl(): string {
+  if (process.env.REACT_APP_BACKEND_URL) {
+    return process.env.REACT_APP_BACKEND_URL;
+  }
+  if (process.env.NODE_ENV === "production") {
+    return "";
+  } else {
+    return "http://localhost:4000";
+  }
+}

--- a/packages/frontend/src/functions/Socket.ts
+++ b/packages/frontend/src/functions/Socket.ts
@@ -1,15 +1,12 @@
 import io from "socket.io-client";
+import { getBackendUrl } from "./Environment";
 
 class Socket {
   private static instance: Socket;
   private s: SocketIOClient.Socket;
 
   private constructor() {
-    let backendUrl = "http://localhost:4000";
-    if (process.env.REACT_APP_BACKEND_URL) {
-      backendUrl = process.env.REACT_APP_BACKEND_URL;
-    }
-    this.s = io(backendUrl);
+    this.s = io(getBackendUrl());
   }
 
   static getInstance(): Socket {

--- a/packages/frontend/src/functions/User.ts
+++ b/packages/frontend/src/functions/User.ts
@@ -1,4 +1,5 @@
 import { User as UserData } from "malte-common/dist/oauth/GitHub";
+import { getBackendUrl } from "../functions/Environment";
 
 export default class User {
   private static user: UserData | null = null;
@@ -10,15 +11,11 @@ export default class User {
   public static async fetchUser(): Promise<
     "success" | "unauthorized" | string
   > {
-    const res = await fetch(
-      `${process.env.REACT_APP_BACKEND_URL ||
-        "http://localhost:4000"}/oauth/github/user`,
-      {
-        method: "GET",
-        credentials: "include",
-        mode: "cors"
-      }
-    );
+    const res = await fetch(`${getBackendUrl()}/oauth/github/user`, {
+      method: "GET",
+      credentials: "include",
+      mode: "cors"
+    });
     if (res.ok) {
       const user = (await res.json()) as UserData;
       User.user = user;
@@ -37,7 +34,7 @@ export default class User {
    */
   public static async authenticate(): Promise<boolean> {
     const w = window.open(
-      `${process.env.REACT_APP_BACKEND_URL}/oauth/github/auth`,
+      `${getBackendUrl()}/oauth/github/auth`,
       "Login with GitHub",
       "chrome=yes,centerscreen,width=800,height=800"
     );


### PR DESCRIPTION
This PR not only reduces code duplication, but also makes "BACKEND_URL" to be an empty string in production unless otherwise specified when deploying.

The reason for this is that when publishing as a single docker image the frontend will be prebuilt and thus they can't specify backend url themselves. Instead, we rely on having same origin between backend and frontend