### PR TITLE
Add persistent sessions to fix bug of client being stuck on disconnect

### DIFF
--- a/packages/backend/src/functions/oauth/GitHub.ts
+++ b/packages/backend/src/functions/oauth/GitHub.ts
@@ -141,13 +141,8 @@ export default class GitHub {
       // Register this session in db
       await addSession(userId, user.id);
     } catch (e) {
-      const isDuplicateSession = e?.code === 11000;
-      if (!isDuplicateSession) {
-        // Duplicate sessions is no big deal, that means the user has a session
-        // anyway. Another error, however, is unexpected
-        console.error(e);
-        return res.sendStatus(500);
-      }
+      console.error(e);
+      return res.sendStatus(500);
     }
 
     // All done! This should have been opened in a popup window, as such

--- a/packages/backend/src/functions/oauth/GitHub.ts
+++ b/packages/backend/src/functions/oauth/GitHub.ts
@@ -137,8 +137,18 @@ export default class GitHub {
       return res.sendStatus(401);
     }
 
-    // Register this session in db
-    await addSession(userId, user.id);
+    try {
+      // Register this session in db
+      await addSession(userId, user.id);
+    } catch (e) {
+      const isDuplicateSession = e?.code === 11000;
+      if (!isDuplicateSession) {
+        // Duplicate sessions is no big deal, that means the user has a session
+        // anyway. Another error, however, is unexpected
+        console.error(e);
+        return res.sendStatus(500);
+      }
+    }
 
     // All done! This should have been opened in a popup window, as such
     // we can now close it

--- a/packages/backend/src/functions/oauth/GitHub.ts
+++ b/packages/backend/src/functions/oauth/GitHub.ts
@@ -8,6 +8,7 @@ import { updateUser } from "./user";
 import { filterUser } from "malte-common/dist/oauth/filterUser";
 import { isFirstTime, unsetFirstTime } from "./firstTime";
 import { addPreApproved, getAllPreapproved } from "../oauth/PreApprovedUser";
+import { addSession } from "../session";
 
 interface AccessTokenResponse {
   access_token: string;
@@ -135,6 +136,9 @@ export default class GitHub {
       this.userIdAccessTokenMap.delete(userId);
       return res.sendStatus(401);
     }
+
+    // Register this session in db
+    await addSession(userId, user.id);
 
     // All done! This should have been opened in a popup window, as such
     // we can now close it

--- a/packages/backend/src/functions/oauth/user.ts
+++ b/packages/backend/src/functions/oauth/user.ts
@@ -1,4 +1,5 @@
 import { User } from "malte-common/dist/oauth/GitHub";
+import { isUser } from "malte-common/dist/oauth/isUser";
 import Database from "../db/Database";
 
 export async function updateUser(user: User): Promise<void> {
@@ -20,4 +21,18 @@ export async function existUser(user: User): Promise<boolean> {
     return true;
   }
   return false;
+}
+
+export async function getUserFromId(id: number): Promise<User | undefined> {
+  const collection = Database.getInstance()
+    .getDb()
+    .collection("users");
+
+  const user = await collection.findOne({ id });
+
+  if (isUser(user)) {
+    return user;
+  } else {
+    return undefined;
+  }
 }

--- a/packages/backend/src/functions/session/Session.ts
+++ b/packages/backend/src/functions/session/Session.ts
@@ -64,9 +64,18 @@ export async function updateSessionTimestamp(userId: string): Promise<void> {
 export async function addSession(userId: string, id: number): Promise<void> {
   const collection = getCollection();
 
-  await collection.insertOne({
-    userId,
-    id,
-    lastSeen: new Date()
-  });
+  try {
+    await collection.insertOne({
+      userId,
+      id,
+      lastSeen: new Date()
+    });
+  } catch (e) {
+    const isDuplicateSession = e?.code === 11000;
+    if (!isDuplicateSession) {
+      // Duplicate sessions is no big deal, that means the user has a session
+      // anyway. Another error, however, is unexpected
+      throw e;
+    }
+  }
 }

--- a/packages/backend/src/functions/session/Session.ts
+++ b/packages/backend/src/functions/session/Session.ts
@@ -1,0 +1,51 @@
+import Database from "../db/Database";
+
+export interface Session {
+  userId: string;
+  socketId: string;
+  id: number;
+}
+
+export async function getSessionFromUserId(userId: string): Promise<Session[]> {
+  const collection = Database.getInstance()
+    .getDb()
+    .collection("sessions");
+
+  const sessions = await collection
+    .find({
+      userId
+    })
+    .toArray();
+
+  return sessions;
+}
+
+export async function removeSessionWithSocketId(
+  socketId: string
+): Promise<number | undefined> {
+  const collection = Database.getInstance()
+    .getDb()
+    .collection("sessions");
+
+  const res = await collection.deleteMany({
+    socketId
+  });
+
+  return res.deletedCount;
+}
+
+export async function addSession(
+  userId: string,
+  socketId: string,
+  id: number
+): Promise<void> {
+  const collection = Database.getInstance()
+    .getDb()
+    .collection("sessions");
+
+  await collection.insertOne({
+    userId,
+    socketId,
+    id
+  });
+}

--- a/packages/backend/src/functions/session/Session.ts
+++ b/packages/backend/src/functions/session/Session.ts
@@ -1,15 +1,34 @@
 import Database from "../db/Database";
+import { Collection } from "mongodb";
+
+// One day in seconds
+const SESSION_EXPIRATION_SECONDS = 1 * 24 * 60 * 60;
 
 export interface Session {
   userId: string;
-  socketId: string;
   id: number;
+  lastSeen: Date;
 }
 
-export async function getSessionFromUserId(userId: string): Promise<Session[]> {
+function getCollection(): Collection<Session> {
   const collection = Database.getInstance()
     .getDb()
-    .collection("sessions");
+    .collection<Session>("sessions");
+
+  collection.createIndex(
+    { lastSeen: 1 },
+    {
+      expireAfterSeconds: SESSION_EXPIRATION_SECONDS
+    }
+  );
+  collection.createIndex({ userId: 1 });
+  collection.createIndex({ id: 1 });
+
+  return collection;
+}
+
+export async function getSession(userId: string): Promise<Session[]> {
+  const collection = getCollection();
 
   const sessions = await collection
     .find({
@@ -20,32 +39,51 @@ export async function getSessionFromUserId(userId: string): Promise<Session[]> {
   return sessions;
 }
 
-export async function removeSessionWithSocketId(
-  socketId: string
+export async function getUserSessions(id: number): Promise<Session[]> {
+  const collection = getCollection();
+
+  const sessions = await collection
+    .find({
+      id
+    })
+    .toArray();
+
+  return sessions;
+}
+
+export async function removeSession(
+  userId: string
 ): Promise<number | undefined> {
-  const collection = Database.getInstance()
-    .getDb()
-    .collection("sessions");
+  const collection = getCollection();
 
   const res = await collection.deleteMany({
-    socketId
+    userId
   });
 
   return res.deletedCount;
 }
 
-export async function addSession(
-  userId: string,
-  socketId: string,
-  id: number
-): Promise<void> {
-  const collection = Database.getInstance()
-    .getDb()
-    .collection("sessions");
+export async function updateSessionTimestamp(userId: string): Promise<void> {
+  const collection = getCollection();
+
+  await collection.updateMany(
+    {
+      userId
+    },
+    {
+      $set: {
+        lastSeen: new Date()
+      }
+    }
+  );
+}
+
+export async function addSession(userId: string, id: number): Promise<void> {
+  const collection = getCollection();
 
   await collection.insertOne({
     userId,
-    socketId,
-    id
+    id,
+    lastSeen: new Date()
   });
 }

--- a/packages/backend/src/functions/session/Session.ts
+++ b/packages/backend/src/functions/session/Session.ts
@@ -21,8 +21,7 @@ function getCollection(): Collection<Session> {
       expireAfterSeconds: SESSION_EXPIRATION_SECONDS
     }
   );
-  collection.createIndex({ userId: 1 });
-  collection.createIndex({ id: 1 });
+  collection.createIndex({ userId: 1 }, { unique: true });
 
   return collection;
 }
@@ -39,34 +38,18 @@ export async function getSession(userId: string): Promise<Session[]> {
   return sessions;
 }
 
-export async function getUserSessions(id: number): Promise<Session[]> {
+export async function removeSession(userId: string): Promise<void> {
   const collection = getCollection();
 
-  const sessions = await collection
-    .find({
-      id
-    })
-    .toArray();
-
-  return sessions;
-}
-
-export async function removeSession(
-  userId: string
-): Promise<number | undefined> {
-  const collection = getCollection();
-
-  const res = await collection.deleteMany({
+  await collection.deleteOne({
     userId
   });
-
-  return res.deletedCount;
 }
 
 export async function updateSessionTimestamp(userId: string): Promise<void> {
   const collection = getCollection();
 
-  await collection.updateMany(
+  await collection.updateOne(
     {
       userId
     },

--- a/packages/backend/src/functions/session/index.ts
+++ b/packages/backend/src/functions/session/index.ts
@@ -1,0 +1,2 @@
+export * from "./Session";
+export { default } from "./Session";

--- a/packages/backend/src/functions/socketServer/SocketServer.ts
+++ b/packages/backend/src/functions/socketServer/SocketServer.ts
@@ -50,7 +50,9 @@ export default class SocketServer {
     userId: string
   ): Promise<void> {
     if (socket.rooms["authenticated"]) {
-      // Already authenticated, let's not join this one again
+      // Already authenticated, let's not join this one again but at least tell
+      // them they are authenticated in case client has lost its state
+      socket.emit("connection/auth-confirm");
       return;
     }
 

--- a/packages/frontend/src/components/Terminal/Terminal.tsx
+++ b/packages/frontend/src/components/Terminal/Terminal.tsx
@@ -16,10 +16,11 @@ const Terminal: React.FC = () => {
     function writeData(data: string) {
       terminal.write(data);
     }
-    function signout() {
+    function dispose() {
       terminal.dispose();
       socket.getSocket().off("pty/data", writeData);
-      socket.getSocket().off("connection/signout", signout);
+      socket.getSocket().off("connection/signout", dispose);
+      socket.getSocket().off("disconnect", dispose);
     }
 
     if (node !== null) {
@@ -37,7 +38,8 @@ const Terminal: React.FC = () => {
 
       socket.getSocket().on("pty/data", writeData);
 
-      socket.getSocket().on("connection/signout", signout);
+      socket.getSocket().on("connection/signout", dispose);
+      socket.getSocket().on("disconnect", dispose);
     }
   }, []);
 

--- a/packages/frontend/src/hooks/useAuthenticationStatus.ts
+++ b/packages/frontend/src/hooks/useAuthenticationStatus.ts
@@ -15,6 +15,8 @@ export default function useAuthenticationStatus() {
     socket.on("connection/auth-confirm", onUpdate);
     socket.on("connection/auth-fail", onUpdate);
     socket.on("connection/signout", onUpdate);
+    socket.on("disconnect", onUpdate);
+    socket.on("reconnect", onUpdate);
 
     return () => {
       socket.removeListener("connection/auth-confirm", onUpdate);


### PR DESCRIPTION
Fixes #193 

Now, when a client disconnects (either server or client loosing connection) you will be tossed onto login screen until you have reconnected.

When reconnection occurs, a new authentication attempt will be made which will throw them back into the frontend

