### PR TITLE
Set focus on Editor after opening / changing tab

### DIFF
--- a/packages/frontend/src/functions/Editor.ts
+++ b/packages/frontend/src/functions/Editor.ts
@@ -44,6 +44,7 @@ export default class Editor {
 
   private onOpenBuffer = (data: { path: string; content: RGAJSON }) => {
     this.openNewBuffer(data.path, data.content);
+    this.focus();
   };
 
   private initCursorChangeListener() {
@@ -77,6 +78,7 @@ export default class Editor {
       this.editor.setModel(file.model);
       // Changed buffer? Let's update cursors
       this.onCursors(this.cursorList);
+      this.focus();
     }
   }
 
@@ -151,6 +153,13 @@ export default class Editor {
     }
 
     this.widgets = newWidgets;
+  }
+
+  /**
+   * Bring browser focus to the text editor
+   */
+  private focus() {
+    this.editor.focus();
   }
 
   public dispose() {

--- a/packages/frontend/src/functions/Editor.ts
+++ b/packages/frontend/src/functions/Editor.ts
@@ -74,12 +74,23 @@ export default class Editor {
           path
         });
     } else {
-      this.activeFile = file;
-      this.editor.setModel(file.model);
-      // Changed buffer? Let's update cursors
-      this.onCursors(this.cursorList);
-      this.focus();
+      this.changeTab(file);
     }
+  }
+
+  private changeTab(file: File) {
+    if (this.activeFile) {
+      this.activeFile.setViewState(this.editor.saveViewState());
+    }
+    this.activeFile = file;
+    this.editor.setModel(file.model);
+    this.onCursors(this.cursorList);
+
+    const activeFileViewState = this.activeFile.getViewState();
+    if (activeFileViewState) {
+      this.editor.restoreViewState(activeFileViewState);
+    }
+    this.focus();
   }
 
   private removeFile(file: File) {
@@ -104,8 +115,7 @@ export default class Editor {
     const file = new File(path, content, newModel);
     this.files.push(file);
 
-    // Let's load this buffer now
-    this.openBuffer(path);
+    this.changeTab(file);
   }
 
   private getModelForBuffer(path: string) {

--- a/packages/frontend/src/functions/File.ts
+++ b/packages/frontend/src/functions/File.ts
@@ -25,6 +25,7 @@ export default class File {
   get model() {
     return this._model;
   }
+  private _viewState: editorType.ICodeEditorViewState | null = null;
 
   private applyingRemote = false;
 
@@ -123,5 +124,12 @@ export default class File {
 
   public getPositionRGA(position: IPosition): RGAIdentifier {
     return this.rga.findNodePos(this.model.getOffsetAt(position)).id;
+  }
+
+  public getViewState(): editorType.ICodeEditorViewState | null {
+    return this._viewState;
+  }
+  public setViewState(newViewState: editorType.ICodeEditorViewState | null) {
+    this._viewState = newViewState;
   }
 }


### PR DESCRIPTION
Resolves #217 

Now the editor is focused on every time that a tab is opened or changed.
The cursor position and scroll position is also stored between tab changes